### PR TITLE
Fix #4 continuous property now working

### DIFF
--- a/UICircularSlider/UICircularSlider.h
+++ b/UICircularSlider/UICircularSlider.h
@@ -73,8 +73,6 @@ typedef enum {
  * If YES, the slider sends update events continuously to the associated target’s action method.
  * If NO, the slider only sends an action event when the user releases the slider’s thumb control to set the final value.
  * The default value of this property is YES.
- *
- * @warning Not implemented Yet.
  */
 @property(nonatomic, getter=isContinuous) BOOL continuous;
 

--- a/UICircularSlider/UICircularSlider.m
+++ b/UICircularSlider/UICircularSlider.m
@@ -39,7 +39,9 @@
 		if (value < self.minimumValue) { value = self.minimumValue; }
 		_value = value;
 		[self setNeedsDisplay];
-		[self sendActionsForControlEvents:UIControlEventValueChanged];
+        if (self.isContinuous) {
+            [self sendActionsForControlEvents:UIControlEventValueChanged];
+        }
 	}
 }
 @synthesize minimumValue = _minimumValue;
@@ -247,6 +249,9 @@
 			break;
 		}
         case UIGestureRecognizerStateEnded:
+            if (!self.isContinuous) {
+                [self sendActionsForControlEvents:UIControlEventValueChanged];
+            }
             if ([self isPointInThumb:tapLocation]) {
                 [self sendActionsForControlEvents:UIControlEventTouchUpInside];
             }

--- a/test_project/UICircularSlider/UICircularSliderViewController.m
+++ b/test_project/UICircularSlider/UICircularSliderViewController.m
@@ -31,8 +31,9 @@
     [self.circularSlider addTarget:self action:@selector(sliderTouchedDown:) forControlEvents:UIControlEventTouchDown];
     [self.circularSlider addTarget:self action:@selector(sliderTouchedUpInside:) forControlEvents:UIControlEventTouchUpInside];
     [self.circularSlider addTarget:self action:@selector(sliderTouchedUpOutside:) forControlEvents:UIControlEventTouchUpOutside];
-	[self.circularSlider setMinimumValue:self.slider.minimumValue];
-	[self.circularSlider setMaximumValue:self.slider.maximumValue];
+	self.circularSlider.minimumValue = self.slider.minimumValue;
+	self.circularSlider.maximumValue =self.slider.maximumValue;
+    self.circularSlider.continuous = NO;
 }
 
 - (void)viewDidUnload {


### PR DESCRIPTION
UICircularSlider's continuous property now available and working like documented:

```
Contains a Boolean value indicating whether changes in the sliders value generate continuous update events.
If YES, the slider sends update events continuously to the associated target’s action method.
If NO, the slider only sends an action event when the user releases the slider’s thumb control to set the final value.
The default value of this property is YES.
```

if `continous == NO`,  `UIControlEventValueChanged` will be sent along with the proper TouchUp event.
